### PR TITLE
Updated package to using uglify-js

### DIFF
--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -1,5 +1,5 @@
 'use strict';
-var UglifyJS = require('uglifyjs');
+var UglifyJS = require('uglify-js');
 var util = require('./util');
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-beautify": "^1.5.4",
     "lodash": "^4.0.1",
     "should": "^10.0.0",
-    "uglifyjs": "^2.4.10"
+    "uglify-js": "^3.0.13"
   },
   "devDependencies": {
     "babel-register": "^6.9.0",


### PR DESCRIPTION
Switching to using `uglify-js` as `uglifyjs` is now deprecated and it means that the `jsdoctest` library is currently unusable on a fresh build:
![image](https://cloud.githubusercontent.com/assets/1018433/26554453/bb8965a6-44c2-11e7-8b8c-c989d06da7f0.png)

I have also switched to using `uglify-js@^3.0.0`, as far I can tell this does not cause issues for this library, but do let me know if you feel it is better to keep with a lateral version switch to `uglify-js@^2.0.0`.

Thanks.