### PR TITLE
Allow tests in class/constructor/property docs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,13 @@ exports.run = function jsdoctest$run(filename) {
 exports.getJsdoctests = function jsdoctest$getJsdoctests(content) {
   var parsedContent = dox.parseComments(content);
   var functionComments = _.filter(parsedContent, function(c) {
-    return c.ctx && (c.ctx.type === 'method' || c.ctx.type === 'function');
+    return c.ctx && (
+      c.ctx.type === 'method'
+      || c.ctx.type === 'function'
+      || c.ctx.type === 'class'
+      || c.ctx.type === 'constructor'
+      || c.ctx.type === 'property'
+    );
   });
 
   var comments = _.map(functionComments, function(comment) {


### PR DESCRIPTION
Currently the following doctests are all silently ignored, which is surprising behavior:
```js
/**
 * @example
 * 1 // => 2
 */
class Foo {
  /**
   * @example
   * 1 // => 2
   */
  constructor()
  /**
   * @example
   * 1 // => 2
   */
  get bar() {
  }
}
```

This patch fixes that.

I tested this locally on the (private) repo where I noticed the problem. Let me know how you'd like additional tests to be added if needed. Also there might be further contexts that should be checked here; I haven't written much JS in a while so not sure.