### PR TITLE
Add support for multiline results #35

### DIFF
--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -91,7 +91,7 @@ exports.parseExamples = function commentParser$parseExamples(parsedComments) {
   var currentCaption;
 
   for(var i = 0, len = parsedComments.length; i < len; i++) {
-    if(parsedComments[i].type === 'code') {
+    if(parsedComments[i].type === 'code' && parsedComments[i].string) {
       if(currentExample.testCase) flush();
 
       currentExample.testCase = parsedComments[i].string

--- a/test/comment-parser.test.js
+++ b/test/comment-parser.test.js
@@ -47,5 +47,63 @@ describe('jsdoctest/comment-parser', function() {
         },
       ]);
     });
+
+    it('handles multiple line results', function() {
+      commentParser.parseExamples(commentParser.parseComments(
+        'map([1, 2, 3], function(x) {\n' +
+        '  return x + 10\n'  +
+        '});\n' +
+        '// => [\n' +
+        '// =>   11,\n' +
+        '// =>   12,\n' +
+        '// =>   13\n' +
+        '// => ]'
+      )).should.eql([
+        {
+          displayTestCase: 'map([1, 2, 3], function(x) {;  return x + 10;})',
+          testCase: 'map([1, 2, 3], function(x) {\n  return x + 10\n})',
+          expectedResult: '[  11,  12,  13]',
+        }
+      ])
+    });
+
+    it('ignores multiple line results if without arrow', function() {
+      commentParser.parseExamples(commentParser.parseComments(
+        'map([1, 2, 3], function(x) {\n' +
+        '  return x + 10\n'  +
+        '});\n' +
+        '// => [\n' +
+        '//      11,\n' +
+        '//      12,\n' +
+        '//      13\n' +
+        '// ]'
+      )).should.eql([
+        {
+          displayTestCase: 'map([1, 2, 3], function(x) {;  return x + 10;})',
+          testCase: 'map([1, 2, 3], function(x) {\n  return x + 10\n})',
+          expectedResult: '[',
+        }
+      ])
+    });
+
+    it('handles multiple line async results', function() {
+      commentParser.parseExamples(commentParser.parseComments(
+        'map([1, 2, 3], function(x) {\n' +
+        '  return x + 10\n'  +
+        '});\n' +
+        '// async => [\n' +
+        '// async =>   11,\n' +
+        '// async =>   12,\n' +
+        '// async =>   13\n' +
+        '// async => ]'
+      )).should.eql([
+        {
+          displayTestCase: 'map([1, 2, 3], function(x) {;  return x + 10;})',
+          testCase: 'map([1, 2, 3], function(x) {\n  return x + 10\n})',
+          expectedResult: '[  11,  12,  13]',
+          isAsync: true
+        }
+      ])
+    });
   });
 });

--- a/test/mocha.test.js
+++ b/test/mocha.test.js
@@ -77,5 +77,34 @@ describe('jsdoctest/mocha', function() {
 
       called.should.be.true;
     });
+
+    it('handles multiline examples', function() {
+      var called = false;
+      var mockModule = {
+        _compile: onCompile
+      };
+
+      mocha.loadDoctests(mockModule, path.join(__dirname, './multiline-file.js'));
+
+      function onCompile(content, filename) {
+        content.should.containEql(
+          '\ndescribe(\'subtract()\', function() {'+
+              'it(\'subtract(1, 2)\', function() {'+
+                '(subtract(1, 2)).should.eql({ normal: -1, reverse: 1 });'+
+              '});\n' +
+              'it(\'subtract(1, 2)\', function() {'+
+                '(subtract(1, 2)).should.eql({  normal: -1,  reverse: 1});'+
+              '});\n' +
+              'it(\'subtract(3, 6)\', function() {'+
+                '(subtract(3, 6)).should.eql({ normal: -3, reverse: 3 });'+
+              '});'+
+            '});'
+        );  
+        called = true;
+        filename.should.equal(path.join(__dirname, 'multiline-file.js'));
+      }
+
+      called.should.be.true;
+    });    
   });
 });

--- a/test/multiline-file.js
+++ b/test/multiline-file.js
@@ -1,0 +1,21 @@
+/**
+ * @example
+ *   subtract(1, 2)
+ *   // => { normal: -1, reverse: 1 }
+ *
+ *   subtract(1, 2)
+ *   // => {
+ *   // =>   normal: -1,
+ *   // =>   reverse: 1
+ *   // => }
+ *
+ *   subtract(3, 6)
+ *   // => { normal: -3, reverse: 3 }
+ */
+
+function subtract(x, y) {
+  return {
+    normal: x - y,
+    reverse: y - x
+  };
+}


### PR DESCRIPTION
Closes #35.

Example usage:

```js
/**
 * @example
 *   subtract(1, 2)
 *   // => {
 *   // =>   normal: -1,
 *   // =>   reverse: 1
 *   // => }
 */

 function subtract(x, y) {
  return {
    normal: x - y,
    reverse: y - x
  };
}
```