### PR TITLE
Support for result => undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lcov
 .vagrant
+.idea

--- a/examples/undefined.js
+++ b/examples/undefined.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * Returns undefined
+ *
+ * @example
+ *    getUndefined()
+ *    // => undefined
+ */
+
+function getUndefined() { }
+exports.getUndefined = getUndefined;

--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -122,9 +122,10 @@ exports.parseExamples = function commentParser$parseExamples(parsedComments) {
       }
     }
 
-    if (!caption)
+    if (!caption) {
       currentExample.label =
           currentExample.testCase + ' => ' + currentExample.expectedResult;
+    }
   }
 
   flush();

--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -121,6 +121,10 @@ exports.parseExamples = function commentParser$parseExamples(parsedComments) {
         currentExample.isAsync = true;
       }
     }
+
+    if (!caption)
+      currentExample.label =
+          currentExample.testCase + ' => ' + currentExample.expectedResult;
   }
 
   flush();

--- a/lib/get-example-code.js
+++ b/lib/get-example-code.js
@@ -21,7 +21,9 @@ function getExampleCode(comment) {
   if(isAsync) {
     return '\nfunction cb(err, result) {' +
       'if(err) return done(err);' +
-      'result.should.eql(' + expectedResult + ');' +
+      (expectedResult === 'undefined'
+          ? '(typeof result).should.eql("undefined");'
+          : 'result.should.eql(' + expectedResult + ');') +
       'done();' +
     '}\n' +
     'var returnValue = ' + testCase + ';' +
@@ -29,7 +31,9 @@ function getExampleCode(comment) {
       'returnValue.then(cb.bind(null, null), cb);' +
     '}';
   } else {
-    return '(' + testCase + ').should.eql(' + expectedResult + ');';
+    return expectedResult === 'undefined'
+        ? '(typeof ' + testCase + ').should.eql("undefined");'
+        : '(' + testCase + ').should.eql(' + expectedResult + ');';
   }
 }
 


### PR DESCRIPTION
Hi, I've made a fork which adds support for desired result being undefined. 

Real life usage:

```javascript
/**
 * Returns the lowest of array's values.
 * If empty, returns undefined.
 * If not all values are numeric, returns NaN.
 *
 * @function
 * @returns {number|undefined}
 *
 * @example <caption>returns 1</caption>
 *    [1, 2, 3, 4, 5, 6].min()
 *    // => 1
 *
 * @example <caption>returns 1</caption>
 *    [{num: 1}, {num: 2}, {num: 3}, {num: 4}, {num: 5}, {num: 6}].map(r => r.num).min()
 *    // => 1
 *
 * @example <caption>returns NaN</caption>
 *    [1, 2, 3, 'Four', 5, 6].min()
 *    // => NaN
 *
 * @example <caption>returns undefined</caption>
 *    [].min()
 *    // => undefined
 */
Array.prototype.min = function() {
  return this.length
      ? Math.min(...this)
      : undefined
}
```